### PR TITLE
Main Menu + UX enhancements and minor bug fixes

### DIFF
--- a/snake.cpp
+++ b/snake.cpp
@@ -96,7 +96,11 @@ void drawMainMenuScreen() {
         std::cout << "2. Toggle Board Size (currently: " << (useHalfSize ? "50%" : "Full") << ")\n";
     }
     std::cout << "3. Quit\n";
-    std::cout << "\nEnter choice (or press M to resume): ";
+    if (gameRunning) {
+        std::cout << "\nEnter choice (or press M or Esc to resume): ";
+    } else {
+        std::cout << "\nEnter choice: ";
+    }
 }
 
 // Generate new food position, not on top of the snake

--- a/snake.cpp
+++ b/snake.cpp
@@ -32,22 +32,108 @@ bool useHalfSize = false;
 bool gameRunning = false;
 bool isPaused = false;
 
-void showMenu(bool allowResize = true) {
-    system("clear");
-    std::cout << "##############################" << std::endl;
-    std::cout << "#          SNAKE            #" << std::endl;
-    std::cout << "##############################" << std::endl;
-    std::cout << std::endl;
-    std::cout << "1. " << (gameRunning ? "Resume Game" : "Start Game") << std::endl;
+void clearScreen() {
+    // Fast: No new process, no shell, it directly writes bytes to the terminal.
+    // Portable: Works in most modern terminal emulators that support ANSI
+    std::cout << "\033[2J\033[H";
+}
 
-    if (allowResize) {
-        std::cout << "2. Toggle Board Size (currently: " << (useHalfSize ? "50%" : "Full") << ")"
-                  << std::endl;
+void drawMainMenuScreen() {
+    // clang-format off
+    const std::vector<std::string> snakeArt = {
+      "#####  ##   #   #  ##  ##  #####",
+      "#       ###  #  # #  # #  ##     ",
+      "#####   # ## # ##### ###   ####  ",
+      "    #   #  ### #   # # #  #     ",
+      "#####   #   ## #   # #  ## ##### ",
+    };
+    // clang-format on
+
+    int artHeight = snakeArt.size();
+    int artWidth = snakeArt[0].length();
+
+    int offsetY = (HEIGHT / 2) - (artHeight / 2) - 2;
+    int offsetX = (WIDTH / 2) - (artWidth / 2);
+
+    for (int y = 0; y < HEIGHT; ++y) {
+        for (int x = 0; x < WIDTH; ++x) {
+            if (y >= offsetY && y < offsetY + artHeight && x >= offsetX && x < offsetX + artWidth) {
+                std::cout << snakeArt[y - offsetY][x - offsetX];
+            } else {
+                std::cout << EMPTY_CHAR;
+            }
+        }
+        std::cout << std::endl;
     }
 
-    std::cout << "3. Quit" << std::endl;
-    std::cout << std::endl;
-    std::cout << "Enter choice (or press M to resume): ";
+    // Print menu text after drawing art
+    std::cout << "\n1. " << (gameRunning ? "Resume Game" : "Start Game") << std::endl;
+    if (!gameRunning) {
+        std::cout << "2. Toggle Board Size (currently: " << (useHalfSize ? "50%" : "Full") << ")\n";
+    }
+    std::cout << "3. Quit\n";
+    std::cout << "\nEnter choice (or press M to resume): ";
+}
+
+// Generate new food position, not on top of the snake
+Coord generateFoodPosition() {
+    Coord newFood;
+    do {
+        newFood.x = std::rand() % (WIDTH - 2) + 1;
+        newFood.y = std::rand() % (HEIGHT - 2) + 1;
+
+        bool onSnake = false;
+        for (const auto &part : snake) {
+            if (part.x == newFood.x && part.y == newFood.y) {
+                onSnake = true;
+                break;
+            }
+        }
+
+        if (!onSnake) break;
+
+    } while (true);
+
+    return newFood;
+}
+
+void initializeDimensions() {
+    struct winsize w;
+    if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &w) == 0) {
+        WIDTH = w.ws_col;
+        HEIGHT = w.ws_row;
+
+        if (WIDTH < 20) WIDTH = 20;
+        if (HEIGHT < 10) HEIGHT = 10;
+        if (HEIGHT > 2) HEIGHT -= 1;
+
+        if (useHalfSize) {
+            WIDTH = WIDTH / 2;
+            HEIGHT = HEIGHT / 2;
+            // TODO: consider making verticalFrames global for dynamic snake speed
+            // verticalFrames = 3;
+        } else {
+            // verticalFrames = 2;
+        }
+    } else {
+        std::cerr << "Could not detect terminal size, using default." << std::endl;
+    }
+}
+
+void initializeGame() {
+    clearScreen();  // clear before first draw
+    gameRunning = true;
+    snake.clear();  // Start snake in center
+    snake.push_back({WIDTH / 2, HEIGHT / 2});
+
+    std::srand(std::time(0));  // Seed random generator
+
+    food = generateFoodPosition();  // Place food somewhere not on the snake
+}
+
+void showMenu(bool allowResize = true) {
+    clearScreen();
+    drawMainMenuScreen();
 
     char choice;
     std::cin >> choice;
@@ -56,11 +142,15 @@ void showMenu(bool allowResize = true) {
         case '1':
         case 'm':
         case 'M':
-        case 27:     // Escape key aka '\x1b'
+        case 27:  // Escape key aka '\x1b'
+            if (!gameRunning) {
+                initializeGame();
+            }
             return;  // Continue
         case '2':
             if (allowResize) {
                 useHalfSize = !useHalfSize;
+                initializeDimensions();
                 showMenu(allowResize);
             } else {
                 showMenu(allowResize);
@@ -76,8 +166,6 @@ void showMenu(bool allowResize = true) {
 }
 
 void drawPauseScreen() {
-    system("clear");
-
     // Example ASCII "PAUSE" banner
     // clang-format off
     const std::vector<std::string> pauseArt = {
@@ -161,28 +249,6 @@ void readInput() {
         }
         // std::cout << "Dir: " << dir << std::endl; // uncomment line to debug key strokes
     }
-}
-
-// Generate new food position, not on top of the snake
-Coord generateFoodPosition() {
-    Coord newFood;
-    do {
-        newFood.x = std::rand() % (WIDTH - 2) + 1;
-        newFood.y = std::rand() % (HEIGHT - 2) + 1;
-
-        bool onSnake = false;
-        for (const auto &part : snake) {
-            if (part.x == newFood.x && part.y == newFood.y) {
-                onSnake = true;
-                break;
-            }
-        }
-
-        if (!onSnake) break;
-
-    } while (true);
-
-    return newFood;
 }
 
 // Returns empty string if no collision, or a reason message if collision
@@ -280,56 +346,19 @@ void drawBoard() {
     }
 }
 
-void initializeGame() {
-    system("clear");  // clear terminal for best view
-    gameRunning = true;
-
-    struct winsize w;
-    if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &w) == 0) {
-        WIDTH = w.ws_col;
-        HEIGHT = w.ws_row;
-
-        // Optional: adjust so it's always at least minimal playable size
-        if (WIDTH < 20) WIDTH = 20;
-        if (HEIGHT < 10) HEIGHT = 10;
-
-        // Reserve one row for prompt so we don't push terminal cursor
-        if (HEIGHT > 2) {
-            HEIGHT -= 1;
-        }
-
-        if (useHalfSize) {
-            WIDTH = WIDTH / 2;
-            HEIGHT = HEIGHT / 2;
-            // TODO: consider making verticalFrames global for dynamic snake speed
-            // verticalFrames = 3;
-        } else {
-            // verticalFrames = 2;
-        }
-    } else {
-        std::cerr << "Could not detect terminal size, using default." << std::endl;
-    }
-
-    snake.clear();  // Start snake in center
-    snake.push_back({WIDTH / 2, HEIGHT / 2});
-
-    std::srand(std::time(0));  // Seed random generator
-
-    food = generateFoodPosition();  // Place food somewhere not on the snake
-}
-
 int main() {
     // terminal throttling vertical vs horizontal due to font discrepancy
     int frameCount = 0;
     const int horizontalFrames = 1;  // Update every frame for horizontal movement
     const int verticalFrames = 2;    // Adjust this to slow down vertical if needed
 
+    initializeDimensions();  // Get terminal size first, for proper art centering
     showMenu();
-    initializeGame();
     setBufferedInput(false);  // Enable raw input
 
     while (true) {
         if (isPaused) {
+            clearScreen();
             drawPauseScreen();
             readInput();
             usleep(100000);

--- a/snake.cpp
+++ b/snake.cpp
@@ -95,7 +95,8 @@ void drawMainMenuScreen() {
     if (!gameRunning) {
         std::cout << "2. Toggle Board Size (currently: " << (useHalfSize ? "50%" : "Full") << ")\n";
     }
-    std::cout << "3. Quit\n";
+    std::cout << "3. View Controls\n";
+    std::cout << "4. Quit\n";
     if (gameRunning) {
         std::cout << "\nEnter choice (or press M or Esc to resume): ";
     } else {
@@ -157,6 +158,39 @@ void initializeGame() {
     std::srand(std::time(0));  // Seed random generator
 
     food = generateFoodPosition();  // Place food somewhere not on the snake
+}
+
+void showControls() {
+    clearScreen();
+
+    std::vector<std::string> lines = {"================= Controls =================",
+                                      "",
+                                      "During Gameplay:",
+                                      "  w - Move up",
+                                      "  a - Move left",
+                                      "  s - Move down",
+                                      "  d - Move right",
+                                      "  p - Pause/Unpause",
+                                      "  m or Esc - Open main menu",
+                                      "  x - Stop (snake stops moving)",
+                                      "",
+                                      "Press any key to return to the main menu..."};
+
+    int startY = (HEIGHT / 2) - (lines.size() / 2);
+    if (startY < 0) startY = 0;
+
+    for (size_t i = 0; i < lines.size(); ++i) {
+        int lineLength = lines[i].length();
+        int startX = (WIDTH / 2) - (lineLength / 2);
+        if (startX < 0) startX = 0;
+
+        std::cout << std::string(startX, ' ') << lines[i] << std::endl;
+    }
+
+    // Wait for any key press to return
+    char dummy;
+    clearScreen();
+    read(STDIN_FILENO, &dummy, 1);
 }
 
 void showMenu(bool allowResize = true) {
@@ -237,6 +271,8 @@ void showMenu(bool allowResize = true) {
             useHalfSize = !useHalfSize;
             initializeDimensions();
         } else if (choice == '3') {
+            showControls();
+        } else if (choice == '4') {
             cleanupAndExit(0);
         }
         // Otherwise loop back and redraw without recursion
@@ -432,9 +468,9 @@ int main() {
     const int horizontalFrames = 1;  // Update every frame for horizontal movement
     const int verticalFrames = 2;    // Adjust this to slow down vertical if needed
 
-    initializeDimensions();  // Get terminal size first, for proper art centering
-    showMenu();
+    initializeDimensions();   // Get terminal size first, for proper art centering
     setBufferedInput(false);  // Enable raw input
+    showMenu();
 
     while (true) {
         if (isPaused) {

--- a/snake.cpp
+++ b/snake.cpp
@@ -196,16 +196,14 @@ void showMenu(bool allowResize = true) {
             // is there.
             ioctl(0, FIONREAD, &bytesWaiting);
 
-            if (bytesWaiting == 2) {
-                char seq[2];
-                read(STDIN_FILENO, &seq[0], 1);
-                read(STDIN_FILENO, &seq[1], 1);
-
-                // Flush any remaining bytes as a safety net
-                ioctl(0, FIONREAD, &bytesWaiting);
+            if (bytesWaiting > 0) {
+                // Start building sequence buffer
+                std::vector<char> seq;
                 while (bytesWaiting > 0) {
-                    char dummy;
-                    read(STDIN_FILENO, &dummy, 1);
+                    char next;
+                    read(STDIN_FILENO, &next, 1);
+                    seq.push_back(next);
+
                     ioctl(0, FIONREAD, &bytesWaiting);
                 }
 
@@ -217,6 +215,8 @@ void showMenu(bool allowResize = true) {
                     std::cout << "\033[H" << std::flush;  // Move cursor to 0,0
                 }
 
+                // seq contains full sequence or multiple sequences
+                // Instead of treating as plain ESC, we can safely continue and redraw
                 continue;  // Ignore arrow keys, redraw menu
             }
             // If no more bytes: plain ESC (close menu)

--- a/snake.cpp
+++ b/snake.cpp
@@ -65,11 +65,11 @@ void cleanupAndExit(int status) {
 void drawMainMenuScreen() {
     // clang-format off
     const std::vector<std::string> snakeArt = {
-      "#####  ##   #   #  ##  ##  #####",
-      "#       ###  #  # #  # #  ##     ",
-      "#####   # ## # ##### ###   ####  ",
-      "    #   #  ### #   # # #  #     ",
-      "#####   #   ## #   # #  ## ##### ",
+      "#####   ##   #    #   ##  ##  #####",
+      "#       ###  #   # #   # #    ##     ",
+      "#####   # ## #  #####  ###    ####  ",
+      "    #   #  ###  #   #  # #    ##     ",
+      "#####   #   ##  #   #  #  #   ###### ",
     };
     // clang-format on
 


### PR DESCRIPTION
# Fixes

- Arrow keys no longer crash or exit menu.
- Rapid combined key presses no longer close menu unexpectedly.
- Cursor no longer jumps or leaves in awkward positions.
- Works properly in both 50% and full screen modes.

Also, see git commit messages for more info. I try my best to keep everything objective focused and descriptive as I iterate.

# Enhancements
- Main Main now renders as a separate view like the Pause menu does
- 50% view now functions identical to full terminal view (default mode)
- "_Enter choice (or press M to resume):_" is now only shown in Main Menu if game is already running
- Added a View Controls menu for players to have better UX
- Improved **S N A K E** ASCII

# Notes

I was going to include score counter and save settings feature in this PR, but now I am going to focus on cleanup + enhancements and do new features in a separate PR. Found a few more small things and feel it's a nicer cut off point.